### PR TITLE
Add kakutey-installer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 | スキル | 説明 |
 |--------|------|
+| **kakutey-installer** | kakutey アプリを GitHub からダウンロード・セットアップする |
 | **kakutey-launcher** | kakutey アプリ（Electron + FastAPI）を起動する |
 | **kakutey-healthcheck** | バックエンド (port 8000) とフロントエンド (port 4200) の稼働確認 |
 | **kakutey-stopper** | kakutey アプリのプロセスを停止する |

--- a/skills/kakutey-installer/SKILL.md
+++ b/skills/kakutey-installer/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: kakutey-installer
+description: Download and set up the kakutey bookkeeping application from GitHub. Run once before first use or after major updates to reinstall dependencies.
+---
+
+# kakutey-installer
+
+kakutey アプリを GitHub からダウンロードし、依存関係をセットアップする。
+
+## 前提条件
+
+| ツール | バージョン | インストール |
+|--------|-----------|-------------|
+| Node.js | v22.12.0 以上 | https://nodejs.org/ |
+| Python | 3.12 以上 | https://www.python.org/ |
+| uv | 最新 | https://docs.astral.sh/uv/getting-started/installation/ |
+
+## 使い方
+
+```bash
+# カレントディレクトリに kakutey/ を作成
+python3 scripts/install.py
+
+# インストール先を指定
+python3 scripts/install.py /path/to/install/dir
+```
+
+## 処理の流れ
+
+1. 前提条件（node, python, uv）のバージョンチェック
+2. GitHub から kakutey ソースコードの zip をダウンロード・展開
+3. バックエンド依存関係のインストール（`uv sync`）
+4. フロントエンド依存関係のインストール（`npm install`）
+
+## インストール後
+
+完了メッセージに表示される `KAKUTEY_FRONTEND_DIR` を環境変数に設定すれば、kakutey-launcher でアプリを起動できる。
+
+## 注意
+
+- インターネット接続が必要
+- すでにインストール先が存在する場合はソースコードを上書き更新する（`node_modules/` や `.venv/` は保持）
+- macOS / Linux / Windows 対応

--- a/skills/kakutey-installer/scripts/install.py
+++ b/skills/kakutey-installer/scripts/install.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""kakutey アプリを GitHub からダウンロードしセットアップする。"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from urllib.request import urlretrieve
+
+REPO_ZIP_URL = "https://github.com/usa-tech-lab/kakutey/archive/refs/heads/main.zip"
+ARCHIVE_PREFIX = "kakutey-main"
+
+
+def check_command(name):
+    """コマンドの存在を確認し、パスを返す。見つからなければ None。"""
+    return shutil.which(name)
+
+
+def get_version(cmd, flag="--version"):
+    """コマンドのバージョン文字列を取得する。"""
+    try:
+        result = subprocess.run(
+            [cmd, flag], capture_output=True, text=True, timeout=10
+        )
+        return result.stdout.strip() or result.stderr.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def parse_version(version_str):
+    """バージョン文字列から (major, minor, patch) タプルを抽出する。"""
+    import re
+
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str or "")
+    if match:
+        return tuple(int(x) for x in match.groups())
+    return None
+
+
+def check_prerequisites():
+    """前提条件をチェックし、問題があれば一覧表示して終了する。"""
+    errors = []
+
+    # Python バージョン（自分自身を確認）
+    if sys.version_info < (3, 12):
+        errors.append(
+            f"  Python 3.12 以上が必要です（現在: {sys.version.split()[0]}）\n"
+            f"  https://www.python.org/"
+        )
+
+    # Node.js
+    node_cmd = check_command("node")
+    if not node_cmd:
+        errors.append(
+            "  node が見つかりません\n"
+            "  https://nodejs.org/"
+        )
+    else:
+        ver = parse_version(get_version("node"))
+        if ver and ver < (22, 12, 0):
+            errors.append(
+                f"  Node.js v22.12.0 以上が必要です（現在: {'.'.join(map(str, ver))}）\n"
+                f"  https://nodejs.org/"
+            )
+
+    # uv
+    if not check_command("uv"):
+        errors.append(
+            "  uv が見つかりません\n"
+            "  https://docs.astral.sh/uv/getting-started/installation/"
+        )
+
+    # npm（Node.js に付属だが念のため確認）
+    if not check_command("npm"):
+        errors.append(
+            "  npm が見つかりません（Node.js と一緒にインストールされます）\n"
+            "  https://nodejs.org/"
+        )
+
+    if errors:
+        print("前提条件を満たしていません:\n")
+        print("\n".join(errors))
+        sys.exit(1)
+
+    print("前提条件チェック OK")
+
+
+def download_and_extract(dest):
+    """GitHub から zip をダウンロードし展開する。"""
+    dest = Path(dest)
+    print(f"ダウンロード中: {REPO_ZIP_URL}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        zip_path = Path(tmp) / "kakutey.zip"
+        urlretrieve(REPO_ZIP_URL, zip_path)
+        print("展開中...")
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmp)
+
+        extracted = Path(tmp) / ARCHIVE_PREFIX
+
+        if dest.exists():
+            print(f"既存ディレクトリを更新: {dest}")
+            # node_modules や .venv は保持しつつソースを上書き
+            for item in extracted.iterdir():
+                target = dest / item.name
+                if item.is_dir():
+                    if target.exists() and item.name in ("node_modules", ".venv"):
+                        continue
+                    if target.exists():
+                        shutil.rmtree(target)
+                    shutil.copytree(item, target)
+                else:
+                    shutil.copy2(item, target)
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(extracted, dest)
+
+    print(f"ソースコード取得完了: {dest}")
+
+
+def install_backend(dest):
+    """バックエンド依存関係をインストールする。"""
+    backend_dir = Path(dest) / "backend"
+    print(f"バックエンドセットアップ中: {backend_dir}")
+    subprocess.run(["uv", "sync"], cwd=backend_dir, check=True)
+    print("バックエンドセットアップ完了")
+
+
+def install_frontend(dest):
+    """フロントエンド依存関係をインストールする。"""
+    frontend_dir = Path(dest) / "frontend"
+    print(f"フロントエンドセットアップ中: {frontend_dir}")
+    subprocess.run(["npm", "install"], cwd=frontend_dir, check=True)
+    print("フロントエンドセットアップ完了")
+
+
+def main():
+    if len(sys.argv) > 1:
+        dest = Path(sys.argv[1]).resolve()
+    else:
+        dest = Path.cwd() / "kakutey"
+
+    print(f"=== kakutey installer ===\n")
+
+    check_prerequisites()
+    print()
+    download_and_extract(dest)
+    print()
+    install_backend(dest)
+    print()
+    install_frontend(dest)
+
+    frontend_dir = dest / "frontend"
+    print(f"\n=== インストール完了 ===")
+    print(f"インストール先: {dest}")
+    print(f"\nkakutey-launcher で起動するには:")
+    print(f"  export KAKUTEY_FRONTEND_DIR={frontend_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- kakutey アプリを GitHub からダウンロード・セットアップする `kakutey-installer` スキルを追加
- Python 標準ライブラリのみ使用し、macOS / Linux / Windows のクロスプラットフォーム対応
- README のスキル一覧に追記

## Test plan

- [ ] `python3 skills/kakutey-installer/scripts/install.py /tmp/kakutey-test` で新規インストールが成功すること
- [ ] 同じパスに再実行し、上書き更新が動作すること
- [ ] 前提条件が不足している環境でエラーメッセージが表示されること

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)