### PR TITLE
Claude Code プラグインマーケットプレイス対応

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "kakutey-marketplace",
+  "owner": {
+    "name": "usa-tech-lab"
+  },
+  "metadata": {
+    "description": "個人事業主向け確定申告ワークフローの Claude Code プラグイン集"
+  },
+  "plugins": [
+    {
+      "name": "kakutey-skills",
+      "source": "./",
+      "description": "kakutey 記帳アプリと連携した確定申告ワークフロー支援プラグイン（19スキル）",
+      "version": "1.0.0",
+      "author": {
+        "name": "usa-tech-lab"
+      },
+      "license": "MIT",
+      "keywords": ["kakutey", "確定申告", "青色申告", "bookkeeping", "tax-return"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "kakutey-skills",
+  "description": "kakutey 記帳アプリと連携した確定申告ワークフロー支援プラグイン",
+  "version": "1.0.0",
+  "author": {
+    "name": "usa-tech-lab"
+  },
+  "homepage": "https://github.com/usa-tech-lab/kakutey-skills",
+  "repository": "https://github.com/usa-tech-lab/kakutey-skills",
+  "license": "MIT",
+  "keywords": ["kakutey", "確定申告", "青色申告", "bookkeeping", "tax-return"]
+}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@
 
 ## インストール
 
+### プラグインとしてインストール（推奨）
+
+Claude Code 内で以下を実行：
+
+```
+/plugin marketplace add usa-tech-lab/kakutey-skills
+/plugin install kakutey-skills@kakutey-marketplace
+```
+
+インストール後、スキルは `/kakutey-skills:スキル名` で呼び出せます（例: `/kakutey-skills:kakutey-bookkeeping`）。
+
+### 手動インストール
+
 ```bash
 # リポジトリをクローン
 git clone https://github.com/usa-tech-lab/kakutey-skills.git


### PR DESCRIPTION
## Summary

- `.claude-plugin/plugin.json` を追加（プラグインマニフェスト）
- `.claude-plugin/marketplace.json` を追加（マーケットプレイスカタログ）
- `README.md` にプラグイン経由のインストール手順を追加

## インストール方法

```
/plugin marketplace add usa-tech-lab/kakutey-skills
/plugin install kakutey-skills@kakutey-marketplace
```

## Test plan

- [ ] `claude plugin validate .` でバリデーションが通ることを確認
- [ ] `claude --plugin-dir .` でプラグインとしてロードされることを確認
- [ ] `/plugin marketplace add ./` でローカルマーケットプレイスが追加できることを確認
- [ ] `/plugin install kakutey-skills@kakutey-marketplace` でインストールできることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)