### PR TITLE
kakutey-installer: インストール先を必ず kakutey/ フォルダにまとめる

### DIFF
--- a/skills/kakutey-installer/SKILL.md
+++ b/skills/kakutey-installer/SKILL.md
@@ -21,9 +21,12 @@ kakutey アプリを GitHub からダウンロードし、依存関係をセッ�
 # カレントディレクトリに kakutey/ を作成
 python3 scripts/install.py
 
-# インストール先を指定
-python3 scripts/install.py /path/to/install/dir
+# 親ディレクトリを指定（kakutey/ は自動付加される）
+python3 scripts/install.py /path/to/parent
+# → /path/to/parent/kakutey/ にインストールされる
 ```
+
+**重要**: インストール先は必ず `kakutey/` フォルダにまとめられる。引数に指定したパスの末尾が `kakutey` でない場合、自動的に `kakutey/` が付加される。ユーザーの作業ディレクトリ直下にアプリファイルを展開してはならない。
 
 ## 処理の流れ
 
@@ -40,4 +43,5 @@ python3 scripts/install.py /path/to/install/dir
 
 - インターネット接続が必要
 - すでにインストール先が存在する場合はソースコードを上書き更新する（`node_modules/` や `.venv/` は保持）
+- インストール先に kakutey 以外のファイルが存在する場合はエラーで中止する
 - macOS / Linux / Windows 対応

--- a/skills/kakutey-installer/scripts/install.py
+++ b/skills/kakutey-installer/scripts/install.py
@@ -12,6 +12,7 @@ from urllib.request import urlretrieve
 
 REPO_ZIP_URL = "https://github.com/usa-tech-lab/kakutey/archive/refs/heads/main.zip"
 ARCHIVE_PREFIX = "kakutey-main"
+KAKUTEY_MARKERS = {"backend", "frontend", "package.json"}
 
 
 def check_command(name):
@@ -88,9 +89,24 @@ def check_prerequisites():
     print("前提条件チェック OK")
 
 
+def validate_existing_dir(dest):
+    """既存ディレクトリが kakutey のインストール先として安全か確認する。"""
+    if not dest.exists():
+        return
+    contents = {item.name for item in dest.iterdir()}
+    if not contents:
+        return  # 空ディレクトリは OK
+    if not contents & KAKUTEY_MARKERS:
+        print(f"エラー: {dest} に kakutey 以外のファイルが存在します。")
+        print(f"既存ファイル: {', '.join(sorted(contents))}")
+        print("別のインストール先を指定するか、ディレクトリを整理してください。")
+        sys.exit(1)
+
+
 def download_and_extract(dest):
     """GitHub から zip をダウンロードし展開する。"""
     dest = Path(dest)
+    validate_existing_dir(dest)
     print(f"ダウンロード中: {REPO_ZIP_URL}")
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -144,6 +160,10 @@ def main():
         dest = Path(sys.argv[1]).resolve()
     else:
         dest = Path.cwd() / "kakutey"
+
+    # インストール先は必ず kakutey/ フォルダにまとめる
+    if dest.name != "kakutey":
+        dest = dest / "kakutey"
 
     print(f"=== kakutey installer ===\n")
 


### PR DESCRIPTION
## Summary

- `install.py`: パスの末尾が `kakutey` でなければ自動的に `kakutey/` を付加
- `install.py`: 既存ディレクトリに kakutey 以外のファイルがある場合はエラーで中止
- `SKILL.md`: 必ず `kakutey/` フォルダにまとめる旨を明記

## Test plan

- [ ] 引数なし → `<cwd>/kakutey/` にインストール
- [ ] `python3 scripts/install.py /tmp/test` → `/tmp/test/kakutey/` にインストール
- [ ] `python3 scripts/install.py /tmp/test/kakutey` → 二重にならない
- [ ] kakutey 以外のファイルがあるディレクトリ → エラーで中止
- [ ] 既存 kakutey インストール → 更新処理が正常動作

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)